### PR TITLE
Add Polymer.IronMenubarBehavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,8 @@
   "ignore": [],
   "dependencies": {
     "iron-selector": "PolymerElements/iron-selector#^v0.9.0",
-    "polymer": "Polymer/polymer#^0.9.0"
+    "polymer": "Polymer/polymer#^0.9.0",
+    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^0.9.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^0.9.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,6 +20,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="simple-menu.html">
+  <link rel="import" href="simple-menubar.html">
 
   <link rel="stylesheet" href="../../paper-styles/demo.css">
 
@@ -46,6 +47,8 @@
 
   <section>
 
+    <div>Simple menu</div>
+
     <simple-menu class="list">
       <li>item 0</li>
       <li>item 1</li>
@@ -57,7 +60,7 @@
 
   <section>
 
-    <div>Multi-select</div>
+    <div>Multi-select menu</div>
 
     <simple-menu class="list" multi>
       <li>item 0</li>
@@ -69,5 +72,29 @@
 
   </section>
 
+  <section>
+
+    <div>Simple menubar</div>
+
+    <simple-menubar class="list">
+      <li>item 0</li>
+      <li>item 1</li>
+      <li disabled>item 2</li>
+      <li>item 3</li>
+    </simple-menubar>
+
+  </section>
+
+  <section>
+    <div>Multi-select menubar</div>
+
+    <simple-menubar class="list" multi>
+      <li>item 0</li>
+      <li>item 1</li>
+      <li>item 2</li>
+      <li>item 3</li>
+      <li>item 4</li>
+    </simple-menubar>
+  </section>
 </body>
 </html>

--- a/demo/simple-menubar.html
+++ b/demo/simple-menubar.html
@@ -1,0 +1,54 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../iron-menubar-behavior.html">
+
+<dom-module id="simple-menubar">
+
+  <style>
+
+    .content ::content > .iron-selected {
+      color: red;
+    }
+
+    .content ::content > * {
+      display: inline-block;
+    }
+
+  </style>
+
+  <template>
+
+    <div class="content">
+      <content></content>
+    </div>
+
+  </template>
+
+</dom-module>
+
+<script>
+
+(function() {
+
+  Polymer({
+
+    is: 'simple-menubar',
+
+    behaviors: [
+      Polymer.IronMenubarBehavior
+    ]
+
+  });
+
+})();
+
+</script>

--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-selector/iron-multi-selectable.html">
+<link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 
 <!--
 `Polymer.IronMenuBehavior` implements accessible menu behavior.
@@ -45,7 +46,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       attrForItemTitle: {
         type: String
       }
-
     },
 
     hostAttributes: {
@@ -56,6 +56,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     listeners: {
       'focus': '_onFocus',
       'keydown': '_onKeydown'
+    },
+
+    keyBindings: {
+      'up': '_onUpKey',
+      'down': '_onDownKey',
+      'esc': '_onEscKey',
+      'enter': '_onEnterKey'
     },
 
     _focusedItemChanged: function(focusedItem, old) {
@@ -94,35 +101,48 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }, 100);
     },
 
+    _onUpKey: function() {
+      // up and down arrows moves the focus
+      this._focusPrevious();
+    },
+
+    _onDownKey: function() {
+      this._focusNext();
+    },
+
+    _onEscKey: function() {
+      // esc blurs the control
+      this.focusedItem.blur();
+    },
+
+    _onEnterKey: function(event) {
+      // enter activates the item unless it is disabled
+      this._activateFocused(event.detail.keyboardEvent);
+    },
+
     _onKeydown: function(event) {
-      // FIXME want to define these somewhere, core-a11y-keys?
-      var DOWN = 40;
-      var UP = 38;
-      var ESC = 27;
-      var ENTER = 13;
-      if (event.keyCode === DOWN) {
-        // up and down arrows moves the focus
-        this._focusNext();
-      } else if (event.keyCode === UP) {
-        this._focusPrevious();
-      } else if (event.keyCode === ESC) {
-        // esc blurs the control
-        this.focusedItem.blur();
-      } else if (event.keyCode === ENTER) {
-        // enter activates the item unless it is disabled
-        if (!this.focusedItem.hasAttribute('disabled')) {
-          this._activateHandler(event);
+      if (this.keyboardEventMatchesKeys(event, 'up down esc enter')) {
+        return;
+      }
+
+      // all other keys focus the menu item starting with that character
+      this._focusWithKeyboardEvent(event);
+    },
+
+    _focusWithKeyboardEvent: function(event) {
+      for (var i = 0, item; item = this.items[i]; i++) {
+        var attr = this.attrForItemTitle || 'textContent';
+        var title = item[attr] || item.getAttribute(attr);
+        if (title && title.trim().charAt(0).toLowerCase() === String.fromCharCode(event.keyCode).toLowerCase()) {
+          this._setFocusedItem(item);
+          break;
         }
-      } else {
-        // all other keys focus the menu item starting with that character
-        for (var i = 0, item; item = this.items[i]; i++) {
-          var attr = this.attrForItemTitle || 'textContent';
-          var title = item[attr] || item.getAttribute(attr);
-          if (title && title.trim().charAt(0).toLowerCase() === String.fromCharCode(event.keyCode).toLowerCase()) {
-            this._setFocusedItem(item);
-            break;
-          }
-        }
+      }
+    },
+
+    _activateFocused: function(event) {
+      if (!this.focusedItem.hasAttribute('disabled')) {
+        this._activateHandler(event);
       }
     },
 
@@ -137,6 +157,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._setFocusedItem(this.items[index]);
     }
 
-  }].concat(Polymer.IronMultiSelectableBehavior);
+  }].concat(
+    Polymer.IronMultiSelectableBehavior,
+    Polymer.IronA11yKeysBehavior
+  );
 
 </script>

--- a/iron-menubar-behavior.html
+++ b/iron-menubar-behavior.html
@@ -1,0 +1,59 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="iron-menu-behavior.html">
+
+<!--
+`Polymer.IronMenubarBehavior` implements accessible menubar behavior.
+-->
+
+<script>
+
+  /** @polymerBehavior */
+  Polymer.IronMenubarBehavior = [{
+
+    hostAttributes: {
+      'role': 'menubar'
+    },
+
+    keyBindings: {
+      'left': '_onLeftKey',
+      'right': '_onRightKey'
+    },
+
+    _onUpKey: function(event) {
+      this._activateFocused(event.detail.keyboardEvent);
+    },
+
+    _onDownKey: function(event) {
+      this._activateFocused(event.detail.keyboardEvent);
+    },
+
+    _onLeftKey: function() {
+      this._focusPrevious();
+    },
+
+    _onRightKey: function() {
+      this._focusNext();
+    },
+
+    _onKeydown: function(event) {
+      if (this.keyboardEventMatchesKeys(event, 'up down left right esc enter')) {
+        return;
+      }
+
+      // all other keys focus the menu item starting with that character
+      this._focusWithKeyboardEvent(event);
+    }
+
+  }].concat(Polymer.IronMenuBehavior);
+
+</script>

--- a/test/iron-menubar-behavior.html
+++ b/test/iron-menubar-behavior.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+
+    <title>iron-menubar-behavior tests</title>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+    <link rel="import" href="../../test-fixture/test-fixture.html">
+    <link rel="import" href="test-menubar.html">
+
+  </head>
+  <body>
+
+    <test-fixture id="basic">
+      <template>
+        <test-menubar>
+          <div>item 1</div>
+          <div>item 2</div>
+          <div>item 3</div>
+        </test-menubar>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="multi">
+      <template>
+        <test-menubar multi>
+          <div>item 1</div>
+          <div>item 2</div>
+          <div>item 3</div>
+        </test-menubar>
+      </template>
+    </test-fixture>
+
+    <script>
+
+      suite('menubar a11y tests', function() {
+
+        test('menubar has role="menubar"', function() {
+          var menubar = fixture('basic');
+          assert.equal(menubar.getAttribute('role'), 'menubar', 'has role="menubar"');
+        });
+
+        test('first item gets focus when menubar is focused', function(done) {
+          var menubar = fixture('basic');
+          menubar.focus();
+          setTimeout(function() {
+            assert.equal(document.activeElement, menubar.firstElementChild, 'document.activeElement is first item')
+            done();
+          // wait for async in _onFocus
+          }, 200);
+        });
+
+        test('selected item gets focus when menubar is focused', function(done) {
+          var menubar = fixture('basic');
+          menubar.selected = 1;
+          menubar.focus();
+          setTimeout(function() {
+            assert.equal(document.activeElement, menubar.selectedItem, 'document.activeElement is selected item');
+            done();
+          // wait for async in _onFocus
+          }, 200);
+        });
+
+        test('last activated item in a multi select menubar is focused', function(done) {
+          var menubar = fixture('multi');
+          menubar.selected = 0;
+          menubar.items[1].click();
+          setTimeout(function() {
+            assert.equal(document.activeElement, menubar.items[1], 'document.activeElement is last activated item');
+            done();
+          // wait for async in _onFocus
+          }, 200);
+        });
+
+        test('deselection in a multi select menubar focuses deselected item', function(done) {
+          var menubar = fixture('multi');
+          menubar.selected = 0;
+          menubar.items[0].click();
+          setTimeout(function() {
+            assert.equal(document.activeElement, menubar.items[0], 'document.activeElement is last activated item');
+            done();
+          // wait for async in _onFocus
+          }, 200);
+        });
+
+      });
+
+    </script>
+
+  </body>
+</html>

--- a/test/test-menubar.html
+++ b/test/test-menubar.html
@@ -1,0 +1,40 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../iron-menubar-behavior.html">
+
+<dom-module id="test-menubar">
+
+  <template>
+
+    <content></content>
+
+  </template>
+
+</dom-module>
+
+<script>
+
+(function() {
+
+  Polymer({
+
+    is: 'test-menubar',
+
+    behaviors: [
+      Polymer.IronMenubarBehavior
+    ]
+
+  });
+
+})();
+
+</script>


### PR DESCRIPTION
A `menubar` is a horizontal menu. It is mostly the same as a `menu`,
but it has distinct understandings of overlapping keybindings, as well
as a few of its own keybindings.

Test suite for IronMenubarBehavior is a shameless rip-off of IronMenuBehavior's test suite.

This PR depends on https://github.com/PolymerElements/iron-a11y-keys-behavior/pull/2

/cc @notwaldorf @blasten 
