### PR TITLE
Clarify type of focusedItem

### DIFF
--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -26,6 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * Returns the currently focused item.
+       * @type {?Object}
        */
       focusedItem: {
         observer: '_focusedItemChanged',


### PR DESCRIPTION
paper-menu sets focusedItem to null, so we need to specify that that's a valid value here.
