### PR TITLE
🐐 Trigger synthetic tap from enter key

### DIFF
--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -179,9 +179,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
+    // trigger a synthetic event tap event from the keypress
+    // so that the common tap event interface across behaviors and components functions correctly
     _activateFocused: function(event) {
       if (!this.focusedItem.hasAttribute('disabled')) {
-        this._activateHandler(event);
+        Polymer.Gestures.fire(Polymer.Gestures.findOriginalTarget(event), 'tap', {
+            x: event.x,
+            y: event.y,
+            sourceEvent: event
+        });
       }
     },
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-menu/issues/40

---

Let me know if this is the totally wrong approach we can iterate on this :)

---

Upon a bit more sniffing... I think https://github.com/PolymerElements/iron-selector/pull/36 might be the "correct" solution here.. however triggering a synthetic "tap" I also think is valuable so I will leave this open
