### PR TITLE
Stop propagation of keyboard events in _onLeftKey() and _onRightKey()…

### DIFF
--- a/iron-menubar-behavior.html
+++ b/iron-menubar-behavior.html
@@ -39,12 +39,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       event.detail.keyboardEvent.preventDefault();
     },
 
-    _onLeftKey: function() {
+    _onLeftKey: function(event) {
       this._focusPrevious();
+      event.detail.keyboardEvent.stopPropagation();
     },
 
-    _onRightKey: function() {
+    _onRightKey: function(event) {
       this._focusNext();
+      event.detail.keyboardEvent.stopPropagation();
     },
 
     _onKeydown: function(event) {


### PR DESCRIPTION
…. This allows apps to register global keyboard shortcuts for the right and left arrow keys without triggering both actions when using keyboard navigation. Fixes PolymerElements/paper-tabs#68
