### PR TITLE
Prevent the selected tab from being refocused when local DOM elements of the menu are focused.

### DIFF
--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -242,7 +242,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Do not focus the selected tab if the deepest target is part of the
       // menu element's local DOM and is focusable.
       var rootTarget = Polymer.dom(event).rootTarget;
-      if (rootTarget !== this && !this.isLightDescendant(rootTarget) && rootTarget.hasAttribute('tabindex')) {
+      if (rootTarget !== this && typeof rootTarget.tabIndex !== "undefined" && !this.isLightDescendant(rootTarget)) {
         return;
       }
 

--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -239,6 +239,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
 
+      // Do not focus the selected tab if the deepest target is part of the
+      // menu element's local DOM and is focusable.
+      var rootTarget = Polymer.dom(event).rootTarget;
+      if (rootTarget !== this && !this.isLightDescendant(rootTarget) && rootTarget.hasAttribute('tabindex')) {
+        return;
+      }
+
       this.blur();
 
       // clear the cached focus item

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -93,7 +93,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var menu = fixture('basic');
           menu.extraContent.focus();
           setTimeout(function() {
-            var menuActiveElement = Polymer.dom(menu.root).querySelector('*:focus');
+            var menuOwnerRoot = Polymer.dom(menu.extraContent).getOwnerRoot() || document;
+            var menuActiveElement = Polymer.dom(menuOwnerRoot).activeElement;
             assert.equal(menuActiveElement, menu.extraContent, 'menu.extraContent is focused');
             done();
           // wait for async in _onFocus

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -72,7 +72,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var menu = fixture('basic');
           MockInteractions.focus(menu);
           setTimeout(function() {
-            assert.equal(document.activeElement, menu.firstElementChild, 'document.activeElement is first item')
+            assert.equal(document.activeElement, menu.firstElementChild, 'document.activeElement is first item');
             done();
           // wait for async in _onFocus
           }, 200);
@@ -84,6 +84,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           MockInteractions.focus(menu);
           setTimeout(function() {
             assert.equal(document.activeElement, menu.selectedItem, 'document.activeElement is selected item');
+            done();
+          // wait for async in _onFocus
+          }, 200);
+        });
+
+        test('focusing non-item content does not auto-focus an item', function(done) {
+          var menu = fixture('basic');
+          menu.extraContent.focus();
+          setTimeout(function() {
+            var menuActiveElement = Polymer.dom(menu.root).querySelector('*:focus');
+            assert.equal(menuActiveElement, menu.extraContent, 'menu.extraContent is focused');
             done();
           // wait for async in _onFocus
           }, 200);

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -72,7 +72,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var menu = fixture('basic');
           MockInteractions.focus(menu);
           setTimeout(function() {
-            assert.equal(document.activeElement, menu.firstElementChild, 'document.activeElement is first item');
+            var ownerRoot = Polymer.dom(menu.firstElementChild).getOwnerRoot() || document;
+            var activeElement = Polymer.dom(ownerRoot).activeElement;
+            assert.equal(activeElement, menu.firstElementChild, 'menu.firstElementChild is focused');
             done();
           // wait for async in _onFocus
           }, 200);
@@ -83,7 +85,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           menu.selected = 1;
           MockInteractions.focus(menu);
           setTimeout(function() {
-            assert.equal(document.activeElement, menu.selectedItem, 'document.activeElement is selected item');
+            var ownerRoot = Polymer.dom(menu.selectedItem).getOwnerRoot() || document;
+            var activeElement = Polymer.dom(ownerRoot).activeElement;
+            assert.equal(activeElement, menu.selectedItem, 'menu.selectedItem is focused');
             done();
           // wait for async in _onFocus
           }, 200);
@@ -96,6 +100,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var menuOwnerRoot = Polymer.dom(menu.extraContent).getOwnerRoot() || document;
             var menuActiveElement = Polymer.dom(menuOwnerRoot).activeElement;
             assert.equal(menuActiveElement, menu.extraContent, 'menu.extraContent is focused');
+            assert.equal(Polymer.dom(document).activeElement, menu, 'menu is document.activeElement');
             done();
           // wait for async in _onFocus
           }, 200);
@@ -106,7 +111,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           menu.selected = 0;
           menu.items[1].click();
           setTimeout(function() {
-            assert.equal(document.activeElement, menu.items[1], 'document.activeElement is last activated item');
+            var ownerRoot = Polymer.dom(menu.items[1]).getOwnerRoot() || document;
+            var activeElement = Polymer.dom(ownerRoot).activeElement;
+            assert.equal(activeElement, menu.items[1], 'menu.items[1] is focused');
             done();
           // wait for async in _onFocus
           }, 200);
@@ -117,7 +124,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           menu.selected = 0;
           menu.items[0].click();
           setTimeout(function() {
-            assert.equal(document.activeElement, menu.items[0], 'document.activeElement is last activated item');
+            var ownerRoot = Polymer.dom(menu.items[0]).getOwnerRoot() || document;
+            var activeElement = Polymer.dom(ownerRoot).activeElement;
+            assert.equal(activeElement, menu.items[0], 'menu.items[0] is focused');
             done();
           // wait for async in _onFocus
           }, 200);

--- a/test/iron-menubar-behavior.html
+++ b/test/iron-menubar-behavior.html
@@ -91,7 +91,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var menubar = fixture('basic');
           menubar.extraContent.focus();
           setTimeout(function() {
-            var menubarActiveElement = Polymer.dom(menubar.root).querySelector('*:focus');
+            var menubarOwnerRoot = Polymer.dom(menubar.extraContent).getOwnerRoot() || document;
+            var menubarActiveElement = Polymer.dom(menubarOwnerRoot).activeElement;
             assert.equal(menubarActiveElement, menubar.extraContent, 'menubar.extraContent is focused');
             done();
           // wait for async in _onFocus

--- a/test/iron-menubar-behavior.html
+++ b/test/iron-menubar-behavior.html
@@ -87,6 +87,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           }, 200);
         });
 
+        test('focusing non-item content does not auto-focus an item', function(done) {
+          var menubar = fixture('basic');
+          menubar.extraContent.focus();
+          setTimeout(function() {
+            var menubarActiveElement = Polymer.dom(menubar.root).querySelector('*:focus');
+            assert.equal(menubarActiveElement, menubar.extraContent, 'menubar.extraContent is focused');
+            done();
+          // wait for async in _onFocus
+          }, 200);
+        });
+
         test('last activated item in a multi select menubar is focused', function(done) {
           var menubar = fixture('multi');
           menubar.selected = 0;

--- a/test/iron-menubar-behavior.html
+++ b/test/iron-menubar-behavior.html
@@ -91,9 +91,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var menubar = fixture('basic');
           menubar.extraContent.focus();
           setTimeout(function() {
-            var menubarOwnerRoot = Polymer.dom(menubar.extraContent).getOwnerRoot() || document;
-            var menubarActiveElement = Polymer.dom(menubarOwnerRoot).activeElement;
-            assert.equal(menubarActiveElement, menubar.extraContent, 'menubar.extraContent is focused');
+            var ownerRoot = Polymer.dom(menubar.extraContent).getOwnerRoot() || document;
+            var activeElement = Polymer.dom(ownerRoot).activeElement;
+            assert.equal(activeElement, menubar.extraContent, 'menubar.extraContent is focused');
+            assert.equal(Polymer.dom(document).activeElement, menubar, 'menubar is document.activeElement');
             done();
           // wait for async in _onFocus
           }, 200);

--- a/test/test-menu.html
+++ b/test/test-menu.html
@@ -17,6 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <content></content>
 
+    <div id="extraContent" tabindex="-1">focusable extra content</div>
+
   </template>
 
 </dom-module>
@@ -31,7 +33,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     behaviors: [
       Polymer.IronMenuBehavior
-    ]
+    ],
+
+    get extraContent() {
+      return this.$.extraContent;
+    }
 
   });
 

--- a/test/test-menubar.html
+++ b/test/test-menubar.html
@@ -17,6 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <content></content>
 
+    <div id="extraContent" tabindex="-1">focusable extra content</div>
+
   </template>
 
 </dom-module>
@@ -31,7 +33,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     behaviors: [
       Polymer.IronMenubarBehavior
-    ]
+    ],
+
+    get extraContent() {
+      return this.$.extraContent;
+    }
 
   });
 


### PR DESCRIPTION
Fixes PolymerElements/paper-tabs#65.
