### PR TITLE
Fixes #50: IronMenuBehavior no longer blurs its host 'in preparation for' focusing something else.

### DIFF
--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -77,6 +77,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @param {string|number} value the value to select.
      */
     select: function(value) {
+      // Cancel automatically focusing a default item if the menu received focus
+      // through a user action selecting a particular item.
       if (this._defaultFocusAsync) {
         this.cancelAsync(this._defaultFocusAsync);
         this._defaultFocusAsync = null;
@@ -247,8 +249,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
 
-      this.blur();
-
       // clear the cached focus item
       this._defaultFocusAsync = this.async(function() {
         // focus the selected item when the menu receives focus, or the first item
@@ -259,11 +259,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         if (selectedItem) {
           this._setFocusedItem(selectedItem);
-        } else {
+        } else if (this.items[0]) {
           this._setFocusedItem(this.items[0]);
         }
-      // async 1ms to wait for `select` to get called from `_itemActivate`
-      }, 1);
+      });
     },
 
     /**

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -46,8 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
-
-   <test-fixture id="nested">
+    <test-fixture id="nested">
       <template>
         <test-menu>
           <test-menu>
@@ -59,10 +58,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="empty">
+      <template>
+        <test-menu></test-menu>
+      </template>
+    </test-fixture>
+
     <script>
-
       suite('menu a11y tests', function() {
-
         test('menu has role="menu"', function() {
           var menu = fixture('basic');
           assert.equal(menu.getAttribute('role'), 'menu', 'has role="menu"');
@@ -71,65 +74,60 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('first item gets focus when menu is focused', function(done) {
           var menu = fixture('basic');
           MockInteractions.focus(menu);
-          setTimeout(function() {
+          Polymer.Base.async(function() {
             var ownerRoot = Polymer.dom(menu.firstElementChild).getOwnerRoot() || document;
             var activeElement = Polymer.dom(ownerRoot).activeElement;
             assert.equal(activeElement, menu.firstElementChild, 'menu.firstElementChild is focused');
             done();
-          // wait for async in _onFocus
-          }, 200);
+          });
         });
 
         test('selected item gets focus when menu is focused', function(done) {
           var menu = fixture('basic');
           menu.selected = 1;
           MockInteractions.focus(menu);
-          setTimeout(function() {
+          Polymer.Base.async(function() {
             var ownerRoot = Polymer.dom(menu.selectedItem).getOwnerRoot() || document;
             var activeElement = Polymer.dom(ownerRoot).activeElement;
             assert.equal(activeElement, menu.selectedItem, 'menu.selectedItem is focused');
             done();
-          // wait for async in _onFocus
-          }, 200);
+          });
         });
 
         test('focusing non-item content does not auto-focus an item', function(done) {
           var menu = fixture('basic');
           menu.extraContent.focus();
-          setTimeout(function() {
+          Polymer.Base.async(function() {
             var menuOwnerRoot = Polymer.dom(menu.extraContent).getOwnerRoot() || document;
             var menuActiveElement = Polymer.dom(menuOwnerRoot).activeElement;
             assert.equal(menuActiveElement, menu.extraContent, 'menu.extraContent is focused');
             assert.equal(Polymer.dom(document).activeElement, menu, 'menu is document.activeElement');
             done();
-          // wait for async in _onFocus
-          }, 200);
+          });
         });
 
         test('last activated item in a multi select menu is focused', function(done) {
           var menu = fixture('multi');
           menu.selected = 0;
           menu.items[1].click();
-          setTimeout(function() {
+          Polymer.Base.async(function() {
             var ownerRoot = Polymer.dom(menu.items[1]).getOwnerRoot() || document;
             var activeElement = Polymer.dom(ownerRoot).activeElement;
             assert.equal(activeElement, menu.items[1], 'menu.items[1] is focused');
             done();
-          // wait for async in _onFocus
-          }, 200);
+          });
         });
 
         test('deselection in a multi select menu focuses deselected item', function(done) {
           var menu = fixture('multi');
           menu.selected = 0;
           menu.items[0].click();
-          setTimeout(function() {
+          Polymer.Base.async(function() {
             var ownerRoot = Polymer.dom(menu.items[0]).getOwnerRoot() || document;
             var activeElement = Polymer.dom(ownerRoot).activeElement;
             assert.equal(activeElement, menu.items[0], 'menu.items[0] is focused');
             done();
-          // wait for async in _onFocus
-          }, 200);
+          });
         });
 
         test('keyboard events should not bubble', function(done) {
@@ -155,16 +153,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // esc
           MockInteractions.keyDownOn(menu.firstElementChild, 27);
 
-          setTimeout(function() {
+          Polymer.Base.async(function() {
             assert.equal(menu.firstElementChild.tagName, 'TEST-MENU');
             assert.equal(keyCounter, 0);
             done();
-          }, 200);
+          });
         });
 
+        test('empty menus don\'t unfocus themselves', function(done) {
+          var menu = fixture('empty');
+
+          menu.focus();
+          Polymer.Base.async(function() {
+            assert.equal(Polymer.dom(document).activeElement, menu);
+            done();
+          });
+        });
       });
-
     </script>
-
   </body>
 </html>

--- a/test/iron-menubar-behavior.html
+++ b/test/iron-menubar-behavior.html
@@ -69,57 +69,52 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('first item gets focus when menubar is focused', function(done) {
           var menubar = fixture('basic');
           MockInteractions.focus(menubar);
-          setTimeout(function() {
+          Polymer.Base.async(function() {
             assert.equal(Polymer.dom(document).activeElement, menubar.firstElementChild, 'document.activeElement is first item')
             done();
-          // wait for async in _onFocus
-          }, 200);
+          });
         });
 
         test('selected item gets focus when menubar is focused', function(done) {
           var menubar = fixture('basic');
           menubar.selected = 1;
           MockInteractions.focus(menubar);
-          setTimeout(function() {
+          Polymer.Base.async(function() {
             assert.equal(Polymer.dom(document).activeElement, menubar.selectedItem, 'document.activeElement is selected item');
             done();
-          // wait for async in _onFocus
-          }, 200);
+          });
         });
 
         test('focusing non-item content does not auto-focus an item', function(done) {
           var menubar = fixture('basic');
           menubar.extraContent.focus();
-          setTimeout(function() {
+          Polymer.Base.async(function() {
             var ownerRoot = Polymer.dom(menubar.extraContent).getOwnerRoot() || document;
             var activeElement = Polymer.dom(ownerRoot).activeElement;
             assert.equal(activeElement, menubar.extraContent, 'menubar.extraContent is focused');
             assert.equal(Polymer.dom(document).activeElement, menubar, 'menubar is document.activeElement');
             done();
-          // wait for async in _onFocus
-          }, 200);
+          });
         });
 
         test('last activated item in a multi select menubar is focused', function(done) {
           var menubar = fixture('multi');
           menubar.selected = 0;
           menubar.items[1].click();
-          setTimeout(function() {
+          Polymer.Base.async(function() {
             assert.equal(Polymer.dom(document).activeElement, menubar.items[1], 'document.activeElement is last activated item');
             done();
-          // wait for async in _onFocus
-          }, 200);
+          });
         });
 
         test('deselection in a multi select menubar focuses deselected item', function(done) {
           var menubar = fixture('multi');
           menubar.selected = 0;
           menubar.items[0].click();
-          setTimeout(function() {
+          Polymer.Base.async(function() {
             assert.equal(Polymer.dom(document).activeElement, menubar.items[0], 'document.activeElement is last activated item');
             done();
-          // wait for async in _onFocus
-          }, 200);
+          });
         });
 
         suite('left / right keys are reversed when the menubar has RTL directionality', function() {


### PR DESCRIPTION
There's no point to blurring if something else is going to be immediately focused afterwards. More importantly, as @robdodson pointed out, this causes elements with IronMenuBehavior which contain no items to become keyboard traps: The user tabs to the menu to focus it, the then menu blurs itself but does not focus anything else in response since it has no items. This causes the focus position to be lost and prevents the user from passing the menu using the keyboard.
