### PR TITLE
Closure compiler fix for iron-menu-behavior.html

### DIFF
--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -241,7 +241,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // Do not focus the selected tab if the deepest target is part of the
       // menu element's local DOM and is focusable.
-      var rootTarget = Polymer.dom(event).rootTarget;
+      var rootTarget = /** @type {?Node} */(Polymer.dom(event).rootTarget);
       if (rootTarget !== this && typeof rootTarget.tabIndex !== "undefined" && !this.isLightDescendant(rootTarget)) {
         return;
       }


### PR DESCRIPTION
Fixes the following closure compiler error in Chromium:

```
## src/third_party/polymer/v1_0/components-chromium/iron-menu-behavior/iron-menu-behavior-extracted.js:229: ERROR - actual parameter 1 of PolymerElement.prototype.isLightDescendant does not match formal parameter
## found   : EventTarget
## required: (Node|null)
##       if (rootTarget !== this && typeof rootTarget.tabIndex !== "undefined" && !this.isLightDescendant(rootTarget)) {
##                                                                                                        ^
```
