### PR TITLE
Fixing #57 Moving focus to next item (in paper-menu) does not skip disabled items.

### DIFF
--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -128,7 +128,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var attr = this.attrForItemTitle || 'textContent';
         var title = item[attr] || item.getAttribute(attr);
 
-        if (title && title.trim().charAt(0).toLowerCase() === String.fromCharCode(event.keyCode).toLowerCase()) {
+        if (!item.hasAttribute('disabled') && title && 
+            title.trim().charAt(0).toLowerCase() === String.fromCharCode(event.keyCode).toLowerCase()) {
           this._setFocusedItem(item);
           break;
         }
@@ -137,21 +138,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     /**
      * Focuses the previous item (relative to the currently focused item) in the
-     * menu.
+     * menu, disabled items will be skipped.
      */
     _focusPrevious: function() {
       var length = this.items.length;
-      var index = (Number(this.indexOf(this.focusedItem)) - 1 + length) % length;
-      this._setFocusedItem(this.items[index]);
+      var curFocusIndex = Number(this.indexOf(this.focusedItem));
+      for (var i = 1; i < length; i++) {
+        var item = this.items[(curFocusIndex - i + length) % length];
+        if (!item.hasAttribute('disabled')) {
+          this._setFocusedItem(item);
+          return;
+        }
+      }
     },
 
     /**
      * Focuses the next item (relative to the currently focused item) in the
-     * menu.
+     * menu, disabled items will be skipped.
      */
     _focusNext: function() {
-      var index = (Number(this.indexOf(this.focusedItem)) + 1) % this.items.length;
-      this._setFocusedItem(this.items[index]);
+      var length = this.items.length;
+      var curFocusIndex = Number(this.indexOf(this.focusedItem));
+      for (var i = 1; i < length; i++) {
+        var item = this.items[(curFocusIndex + i) % length];
+        if (!item.hasAttribute('disabled')) {
+          this._setFocusedItem(item);
+          return;
+        }
+      }
     },
 
     /**
@@ -260,7 +274,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (selectedItem) {
           this._setFocusedItem(selectedItem);
         } else if (this.items[0]) {
-          this._setFocusedItem(this.items[0]);
+          // We find the first none-disabled item (if one exists)
+          this._focusNext();
         }
       });
     },

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -36,6 +36,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="disabled">
+      <template>
+        <test-menu>
+          <div>a item 1</div>
+          <div disabled>b item 2</div>
+          <div>b item 3</div>
+          <div disabled>c item 4</div>
+        </test-menu>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="only-disabled">
+      <template>
+        <test-menu>
+          <div disabled>disabled item</div>
+        </test-menu>
+      </template>
+    </test-fixture>
+
     <test-fixture id="multi">
       <template>
         <test-menu multi>
@@ -91,6 +110,156 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var activeElement = Polymer.dom(ownerRoot).activeElement;
             assert.equal(activeElement, menu.selectedItem, 'menu.selectedItem is focused');
             done();
+          });
+        });
+
+        test('focusing on next item skips disabled items', function(done) {
+          var menu = fixture('disabled');
+          MockInteractions.focus(menu);
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press down
+            MockInteractions.keyDownOn(menu, 40);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem, menu.items[2], 'menu.items[2] is focused');
+              done();
+            });
+          });
+        });
+
+        test('focusing on next item in empty menu', function(done) {
+          var menu = fixture('empty');
+          MockInteractions.focus(menu);
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press down
+            MockInteractions.keyDownOn(menu, 40);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem, undefined, 'no focused item');
+              done();
+            });
+          });
+        });
+
+        test('focusing on next item in all disabled menu', function(done) {
+          var menu = fixture('only-disabled');
+          MockInteractions.focus(menu);
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press down
+            MockInteractions.keyDownOn(menu, 40);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem, undefined, 'no focused item');
+              done();
+            });
+          });
+        });
+
+        test('focusing on previous item skips disabled items', function(done) {
+          var menu = fixture('disabled');
+          MockInteractions.focus(menu);
+
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press up
+            MockInteractions.keyDownOn(menu, 38);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem, menu.items[2], 'menu.items[2] is focused');
+              done();
+            });
+          });
+        });
+
+        test('focusing on previous item in empty menu', function(done) {
+          var menu = fixture('empty');
+          MockInteractions.focus(menu);
+
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press up
+            MockInteractions.keyDownOn(menu, 38);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem,  undefined, 'no focused item');
+              done();
+            });
+          });
+        });
+
+        test('focusing on previous item in all disabled menu', function(done) {
+          var menu = fixture('only-disabled');
+          MockInteractions.focus(menu);
+
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press up
+            MockInteractions.keyDownOn(menu, 38);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem,  undefined, 'no focused item');
+              done();
+            });
+          });
+        });
+
+        test('focusing on item using key press skips disabled items', function(done) {
+          var menu = fixture('disabled');
+          MockInteractions.focus(menu);
+
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press 'b'
+            MockInteractions.keyDownOn(menu, 66);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem, menu.items[2], 'menu.items[2] is focused');
+              done();
+            });
+          });
+        });
+
+        test('focusing on item using key press ignores disabled items', function(done) {
+          var menu = fixture('disabled');
+          MockInteractions.focus(menu);
+
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press 'c'
+            MockInteractions.keyDownOn(menu, 67);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem, menu.items[0], 'menu.items[0] is focused');
+              done();
+            });
+          });
+        });
+
+        test('focusing on item using key press in all disabled items', function(done) {
+          var menu = fixture('only-disabled');
+          MockInteractions.focus(menu);
+
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press 'c'
+            MockInteractions.keyDownOn(menu, 67);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem,  undefined, 'no focused item');
+              done();
+            });
           });
         });
 


### PR DESCRIPTION
Fixing #57 
We are looking at the 'disabled' html dom attribute rather then the iron-control-state 'disabled' property for more generic support.
