### PR TITLE
Fixing focus issues for menus with single item (#66)

### DIFF
--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -139,11 +139,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * Focuses the previous item (relative to the currently focused item) in the
      * menu, disabled items will be skipped.
+     * Loop until length + 1 to handle case of singe item in menu.
      */
     _focusPrevious: function() {
       var length = this.items.length;
       var curFocusIndex = Number(this.indexOf(this.focusedItem));
-      for (var i = 1; i < length; i++) {
+      for (var i = 1; i < length + 1; i++) {
         var item = this.items[(curFocusIndex - i + length) % length];
         if (!item.hasAttribute('disabled')) {
           this._setFocusedItem(item);
@@ -155,11 +156,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     /**
      * Focuses the next item (relative to the currently focused item) in the
      * menu, disabled items will be skipped.
+     * Loop until length + 1 to handle case of singe item in menu.
      */
     _focusNext: function() {
       var length = this.items.length;
       var curFocusIndex = Number(this.indexOf(this.focusedItem));
-      for (var i = 1; i < length; i++) {
+      for (var i = 1; i < length + 1; i++) {
         var item = this.items[(curFocusIndex + i) % length];
         if (!item.hasAttribute('disabled')) {
           this._setFocusedItem(item);

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -36,6 +36,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+     <test-fixture id="single-item">
+      <template>
+        <test-menu>
+          <div>item 1</div>
+        </test-menu>
+      </template>
+    </test-fixture>
+
     <test-fixture id="disabled">
       <template>
         <test-menu>
@@ -92,6 +100,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('first item gets focus when menu is focused', function(done) {
           var menu = fixture('basic');
+          MockInteractions.focus(menu);
+          Polymer.Base.async(function() {
+            var ownerRoot = Polymer.dom(menu.firstElementChild).getOwnerRoot() || document;
+            var activeElement = Polymer.dom(ownerRoot).activeElement;
+            assert.equal(activeElement, menu.firstElementChild, 'menu.firstElementChild is focused');
+            done();
+          });
+        });
+
+        test('first item gets focus when menu is focused in a single item menu', function(done) {
+          var menu = fixture('single-item');
           MockInteractions.focus(menu);
           Polymer.Base.async(function() {
             var ownerRoot = Polymer.dom(menu.firstElementChild).getOwnerRoot() || document;


### PR DESCRIPTION
Fixing: _focusNext & _focusPrevious will skip focusing if the menu has only 1 item #66 
Looping until length+1 in _focusNext & _focusPrevious to handle cases of menus with a single item.
Added a test to validate the case as well.
