### PR TITLE
_focusNext and _focusPrevious should skip unfocusable items

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -67,7 +67,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <a href="javascript:void(0)" role="menuitem">Item 0</a>
           <a href="javascript:void(0)" role="menuitem">Item 1</a>
           <a href="javascript:void(0)" role="menuitem" disabled>Item 2</a>
+          <a href="javascript:void(0)" role="menuitem" hidden>Ghost</a>
           <a href="javascript:void(0)" role="menuitem">Item 3</a>
+          <a href="javascript:void(0)" role="menuitem" style="display:none">Another ghost</a>
         </simple-menu>
       </div>
     </div>
@@ -77,9 +79,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div class="horizontal-section">
         <simple-menu multi>
           <a href="javascript:void(0)" role="menuitem">Item 0</a>
-          <a href="javascript:void(0)" role="menuitem">Item 1</a>
+          <a href="javascript:void(0)" role="menuitem" disabled>Item 1</a>
+          <a href="javascript:void(0)" role="menuitem" hidden>Ghost</a>
           <a href="javascript:void(0)" role="menuitem">Item 2</a>
           <a href="javascript:void(0)" role="menuitem">Item 3</a>
+          <a href="javascript:void(0)" role="menuitem" style="display:none">Another ghost</a>
         </simple-menu>
       </div>
     </div>

--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -144,10 +144,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _focusPrevious: function() {
       var length = this.items.length;
       var curFocusIndex = Number(this.indexOf(this.focusedItem));
-      var owner = Polymer.dom(this).getOwnerRoot() || document;
 
       for (var i = 1; i < length + 1; i++) {
         var item = this.items[(curFocusIndex - i + length) % length];
+        var owner = Polymer.dom(item).getOwnerRoot() || document;
         if (!item.hasAttribute('disabled')) {
           this._setFocusedItem(item);
 
@@ -168,11 +168,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _focusNext: function() {
       var length = this.items.length;
       var curFocusIndex = Number(this.indexOf(this.focusedItem));
-      var owner = Polymer.dom(this).getOwnerRoot() || document;
 
       for (var i = 1; i < length + 1; i++) {
         var item = this.items[(curFocusIndex + i) % length];
-
+        var owner = Polymer.dom(item).getOwnerRoot() || document;
         if (!item.hasAttribute('disabled')) {
           this._setFocusedItem(item);
 

--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -144,11 +144,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _focusPrevious: function() {
       var length = this.items.length;
       var curFocusIndex = Number(this.indexOf(this.focusedItem));
+      var owner = Polymer.dom(this).getOwnerRoot() || document;
+
       for (var i = 1; i < length + 1; i++) {
         var item = this.items[(curFocusIndex - i + length) % length];
         if (!item.hasAttribute('disabled')) {
           this._setFocusedItem(item);
-          return;
+
+          // Focus might not have worked, if the element was hidden or not
+          // focusable. In that case, try again.
+          if (Polymer.dom(owner).activeElement == item) {
+            return;
+          }
         }
       }
     },
@@ -161,11 +168,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _focusNext: function() {
       var length = this.items.length;
       var curFocusIndex = Number(this.indexOf(this.focusedItem));
+      var owner = Polymer.dom(this).getOwnerRoot() || document;
+
       for (var i = 1; i < length + 1; i++) {
         var item = this.items[(curFocusIndex + i) % length];
+
         if (!item.hasAttribute('disabled')) {
           this._setFocusedItem(item);
-          return;
+
+          // Focus might not have worked, if the element was hidden or not
+          // focusable. In that case, try again.
+          if (Polymer.dom(owner).activeElement == item) {
+            return;
+          }
         }
       }
     },

--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -147,8 +147,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       for (var i = 1; i < length + 1; i++) {
         var item = this.items[(curFocusIndex - i + length) % length];
-        var owner = Polymer.dom(item).getOwnerRoot() || document;
         if (!item.hasAttribute('disabled')) {
+          var owner = Polymer.dom(item).getOwnerRoot() || document;
           this._setFocusedItem(item);
 
           // Focus might not have worked, if the element was hidden or not
@@ -171,8 +171,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       for (var i = 1; i < length + 1; i++) {
         var item = this.items[(curFocusIndex + i) % length];
-        var owner = Polymer.dom(item).getOwnerRoot() || document;
         if (!item.hasAttribute('disabled')) {
+          var owner = Polymer.dom(item).getOwnerRoot() || document;
           this._setFocusedItem(item);
 
           // Focus might not have worked, if the element was hidden or not

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -22,7 +22,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../web-component-tester/browser.js"></script>
     <script src="../../iron-test-helpers/mock-interactions.js"></script>
     <link rel="import" href="test-menu.html">
+    <link rel="import" href="test-nested-menu.html">
 
+    <style>
+      .ghost, [hidden] {
+        display: none;
+      }
+    </style>
   </head>
   <body>
 
@@ -52,6 +58,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <div>b item 3</div>
           <div disabled>c item 4</div>
         </test-menu>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="invisible">
+      <template>
+        <test-menu>
+          <div>item 1</div>
+          <div hidden>item 2</div>
+          <div class="ghost">item 3</div>
+          <div>item 4</div>
+          <div hidden>item 5</div>
+          <div class="ghost">item 6</div>
+        </test-menu>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="nested-invisible">
+      <template>
+        <test-nested-menu></test-nested-menu>
       </template>
     </test-fixture>
 
@@ -148,6 +173,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('focusing on next item skips invisible items', function(done) {
+          var menu = fixture('invisible');
+
+          MockInteractions.focus(menu);
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press down
+            MockInteractions.keyDownOn(menu, 40);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem, menu.items[3], 'menu.items[3] is focused');
+              done();
+            });
+          });
+        });
+
+        test('focusing on next item skips nested invisible items', function(done) {
+          var nestedMenu = fixture('nested-invisible');
+          var menu = nestedMenu.$.actualMenu;
+
+          MockInteractions.focus(menu);
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press down
+            MockInteractions.keyDownOn(menu, 40);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem, menu.items[3], 'menu.items[3] is focused');
+              done();
+            });
+          });
+        });
+
         test('focusing on next item in empty menu', function(done) {
           var menu = fixture('empty');
           MockInteractions.focus(menu);
@@ -192,6 +252,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             Polymer.Base.async(function() {
               var focusedItem = Polymer.dom(menu).node.focusedItem;
               assert.equal(focusedItem, menu.items[2], 'menu.items[2] is focused');
+              done();
+            });
+          });
+        });
+
+        test('focusing on previous item skips invisible items', function(done) {
+          var menu = fixture('invisible');
+          MockInteractions.focus(menu);
+
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press up
+            MockInteractions.keyDownOn(menu, 38);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem, menu.items[3], 'menu.items[3] is focused');
+              done();
+            });
+          });
+        });
+
+        test('focusing on previous item skips nested invisible items', function(done) {
+          var nestedMenu = fixture('nested-invisible');
+          var menu = nestedMenu.$.actualMenu;
+          MockInteractions.focus(menu);
+
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press up
+            MockInteractions.keyDownOn(menu, 38);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem, menu.items[3], 'menu.items[3] is focused');
               done();
             });
           });

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -28,6 +28,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       .ghost, [hidden] {
         display: none;
       }
+      .invisible {
+        visibility: hidden;
+      }
     </style>
   </head>
   <body>
@@ -67,6 +70,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <div>item 1</div>
           <div hidden>item 2</div>
           <div class="ghost">item 3</div>
+          <div class="invisible">item 3.1</div>
           <div>item 4</div>
           <div hidden>item 5</div>
           <div class="ghost">item 6</div>
@@ -184,7 +188,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             Polymer.Base.async(function() {
               var focusedItem = Polymer.dom(menu).node.focusedItem;
-              assert.equal(focusedItem, menu.items[3], 'menu.items[3] is focused');
+              assert.equal(focusedItem, menu.items[4], 'menu.items[4] is focused');
               done();
             });
           });
@@ -202,7 +206,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             Polymer.Base.async(function() {
               var focusedItem = Polymer.dom(menu).node.focusedItem;
-              assert.equal(focusedItem, menu.items[3], 'menu.items[3] is focused');
+              assert.equal(focusedItem, menu.items[4], 'menu.items[4] is focused');
               done();
             });
           });
@@ -268,7 +272,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             Polymer.Base.async(function() {
               var focusedItem = Polymer.dom(menu).node.focusedItem;
-              assert.equal(focusedItem, menu.items[3], 'menu.items[3] is focused');
+              assert.equal(focusedItem, menu.items[4], 'menu.items[4] is focused');
               done();
             });
           });
@@ -286,7 +290,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             Polymer.Base.async(function() {
               var focusedItem = Polymer.dom(menu).node.focusedItem;
-              assert.equal(focusedItem, menu.items[3], 'menu.items[3] is focused');
+              assert.equal(focusedItem, menu.items[4], 'menu.items[4] is focused');
               done();
             });
           });

--- a/test/test-nested-menu.html
+++ b/test/test-nested-menu.html
@@ -17,11 +17,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       .ghost, [hidden] {
         display: none !important;
       }
+      .invisible {
+        visibility: hidden;
+      }
     </style>
     <test-menu id="actualMenu">
       <div>item 1</div>
       <div hidden>item 2</div>
       <div class="ghost">item 3</div>
+      <div class="invisible">item 3.1</div>
       <div>item 4</div>
       <div hidden>item 5</div>
       <div class="ghost">item 6</div>

--- a/test/test-nested-menu.html
+++ b/test/test-nested-menu.html
@@ -1,0 +1,40 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="test-menu.html">
+
+<dom-module id="test-nested-menu">
+  <template>
+    <style>
+      .ghost, [hidden] {
+        display: none !important;
+      }
+    </style>
+    <test-menu id="actualMenu">
+      <div>item 1</div>
+      <div hidden>item 2</div>
+      <div class="ghost">item 3</div>
+      <div>item 4</div>
+      <div hidden>item 5</div>
+      <div class="ghost">item 6</div>
+    </test-menu>
+  </template>
+</dom-module>
+
+<script>
+
+(function() {
+  Polymer({
+    is: 'test-nested-menu',
+  });
+})();
+
+</script>


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-menu-behavior/issues/72: along with `disabled` items, these methods should skip things that aren't focusable (like invisible items).

👀🙏 @bicknellr 

/cc @danbeam 
