### PR TITLE
Set aria-selected="false" on deselected items

### DIFF
--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -234,7 +234,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     _onIronItemsChanged: function(event) {
       if (event.detail.addedNodes.length) {
-        console.log('iron-menu-behavior: _onIronItemsChanged');
         this._resetItemAttributes();
       }
     },

--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -98,8 +98,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * other items.
      *
      * Reset the aria-selected attribute based on the current selection state.
-     * As _applySelection notes, we need to set aria-selected to false to items,
-     * even in their initial state, not just when they become deselected.
+     * As _applySelection notes, we need to set aria-selected to false for
+     * unselected items, even in their initial state, not just when they become
+     * deselected.
      */
     _resetItemAttributes: function() {
       var selectedItem = this.multi ? (this.selectedItems && this.selectedItems[0]) : this.selectedItem;

--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -67,7 +67,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
-      this._resetTabindices();
+      this._resetItemAttributes();
     },
 
     /**
@@ -90,16 +90,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     /**
-     * Resets all tabindex attributes to the appropriate value based on the
+     * Reset attributes of the menu's new/changed collection of items:
+     *
+     * Reset all tabindex attributes to the appropriate value based on the
      * current selection state. The appropriate value is `0` (focusable) for
      * the default selected item, and `-1` (not keyboard focusable) for all
      * other items.
+     *
+     * Reset the aria-selected attribute based on the current selection state.
+     * As _applySelection notes, we need to set aria-selected to false to items,
+     * even in their initial state, not just when they become deselected.
      */
-    _resetTabindices: function() {
+    _resetItemAttributes: function() {
       var selectedItem = this.multi ? (this.selectedItems && this.selectedItems[0]) : this.selectedItem;
 
       this.items.forEach(function(item) {
-        item.setAttribute('tabindex', item === selectedItem ? '0' : '-1');
+        var isSelected = item === selectedItem;
+        item.setAttribute('tabindex', isSelected ? '0' : '-1');
+        item.setAttribute('aria-selected', isSelected);
       }, this);
     },
 
@@ -193,11 +201,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * selected state, otherwise false.
      */
     _applySelection: function(item, isSelected) {
-      if (isSelected) {
-        item.setAttribute('aria-selected', 'true');
-      } else {
-        item.removeAttribute('aria-selected');
-      }
+      // Per the ARIA spec at https://www.w3.org/TR/wai-aria-1.1/#tab:
+      // "inactive tab elements [should] have their aria-selected attribute set
+      // to false".
+      item.setAttribute('aria-selected', isSelected);
       Polymer.IronSelectableBehavior._applySelection.apply(this, arguments);
     },
 
@@ -226,7 +233,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     _onIronItemsChanged: function(event) {
       if (event.detail.addedNodes.length) {
-        this._resetTabindices();
+        console.log('iron-menu-behavior: _onIronItemsChanged');
+        this._resetItemAttributes();
       }
     },
 

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -497,6 +497,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           });
         });
+
+        test('aria-selected attribute for items defaults to false', function() {
+          var menu = fixture('basic');
+          var selectedValues = menu.items.map(function(item) {
+            return item.getAttribute('aria-selected');
+          });
+          assert.deepEqual(selectedValues, ['false', 'false', 'false']);
+        });
+
+        test('aria-selected attribute reflects item selection state', function() {
+          var menu = fixture('basic');
+          var item0 = menu.items[0];
+          var item1 = menu.items[1];
+          assert.equal(item0.getAttribute('aria-selected'), 'false');
+          assert.equal(item1.getAttribute('aria-selected'), 'false');
+          menu.selected = 0;
+          assert.equal(item0.getAttribute('aria-selected'), 'true');
+          assert.equal(item1.getAttribute('aria-selected'), 'false');
+          menu.selected = 1;
+          assert.equal(item0.getAttribute('aria-selected'), 'false');
+          assert.equal(item1.getAttribute('aria-selected'), 'true');
+        });
+
       });
     </script>
   </body>


### PR DESCRIPTION
As @giltza noted in the original issue on paper-tabs, the `aria-selected` attribute should be set to "false" for deselected items, not removed.

This PR handles two situations: 1) ensures that all items start out with `aria-selected="false"` by default, 2) sets `aria-selected="false"` when a individual item is explicitly deselected.

I've tested this fix under the indicated Windows screen reader, NVDA, and confirmed that paper-tabs now works as expected:
- When using the arrow keys to navigate horizontally among paper-tabs, the name of each tab is announced.
- The screen reader will only announce that the tab is selected if the tab is actually selected. (Previously, the screen reader would announce that the tab was selected, even if it was not, because unselected tabs were missing the `aria-selected` attribute.)
