### PR TITLE
Fix a bug where iron-menu-behavior swallowed all keydown

### DIFF
--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -124,6 +124,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * menu (if there is a relevant item, and it is possible to focus it).
      *
      * @param {KeyboardEvent} event A KeyboardEvent.
+     * @return {boolean} Whether an item was focused.
      */
     _focusWithKeyboardEvent: function(event) {
       this.cancelDebouncer('_clearSearchText');
@@ -134,6 +135,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       searchText += key.toLocaleLowerCase();
 
       var searchLength = searchText.length;
+      var itemWasFocused = false;
 
       for (var i = 0, item; item = this.items[i]; i++) {
         if (item.hasAttribute('disabled')) {
@@ -149,6 +151,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         if (title.slice(0, searchLength).toLocaleLowerCase() == searchText) {
           this._setFocusedItem(item);
+          itemWasFocused = true;
           break;
         }
       }
@@ -156,6 +159,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._searchText = searchText;
       this.debounce('_clearSearchText', this._clearSearchText,
                     this._SEARCH_RESET_TIMEOUT_MS);
+      return itemWasFocused;
     },
 
     _clearSearchText: function() {
@@ -352,9 +356,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _onKeydown: function(event) {
       if (!this.keyboardEventMatchesKeys(event, 'up down esc')) {
         // all other keys focus the menu item starting with that character
-        this._focusWithKeyboardEvent(event);
+        if (this._focusWithKeyboardEvent(event)) {
+          event.stopPropagation();
+        }
+      } else {
+        event.stopPropagation();
       }
-      event.stopPropagation();
     },
 
     // override _activateHandler

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -434,7 +434,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               done();
             });
           });
+        });
 
+        test('keypress which does not focus item does not stop event propagation', function(done) {
+          var menu = fixture('multi');
+          MockInteractions.focus(menu);
+
+          var onKeyDown = false;
+          menu.parentElement.addEventListener("keydown", function(event) {
+            onKeyDown = true;
+	  });
+
+          // Wait for async focus
+          Polymer.Base.async(function() {
+            // Key press 'u'
+            MockInteractions.keyDownOn(menu, 85);
+
+            Polymer.Base.async(function() {
+              var focusedItem = Polymer.dom(menu).node.focusedItem;
+              assert.equal(focusedItem, menu.items[0], 'menu.items[0] is still focused');       
+              assert.equal(onKeyDown, true);       
+              done();
+            });
+          });
         });
 
         test('focusing non-item content does not auto-focus an item', function(done) {

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -443,7 +443,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var onKeyDown = false;
           menu.parentElement.addEventListener("keydown", function(event) {
             onKeyDown = true;
-	  });
+          });
 
           // Wait for async focus
           Polymer.Base.async(function() {


### PR DESCRIPTION
This fixes #82 by only calling stopPropagation() on the event if an item was actually focused.