### PR TITLE
Disabled menu should not be in tab order

### DIFF
--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -41,14 +41,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        */
       attrForItemTitle: {
         type: String
-      }
+      },
+
+      disabled: {
+        type: Boolean,
+        value: false,
+        observer: '_disabledChanged',
+      },
     },
 
     _SEARCH_RESET_TIMEOUT_MS: 1000,
 
+    _previousTabIndex: 0,
+
     hostAttributes: {
       'role': 'menu',
-      'tabindex': '0'
     },
 
     observers: [
@@ -237,7 +244,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     _focusedItemChanged: function(focusedItem, old) {
       old && old.setAttribute('tabindex', '-1');
-      if (focusedItem) {
+      if (focusedItem && !focusedItem.hasAttribute('disabled') && !this.disabled) {
         focusedItem.setAttribute('tabindex', '0');
         focusedItem.focus();
       }
@@ -361,6 +368,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _activateHandler: function(event) {
       Polymer.IronSelectableBehavior._activateHandler.call(this, event);
       event.stopPropagation();
+    },
+
+    /**
+     * Updates this element's tab index when it's enabled/disabled.
+     * @param {boolean} disabled
+     */
+    _disabledChanged: function(disabled) {
+      if (disabled) {
+        this._previousTabIndex = this.hasAttribute('tabindex') ? this.tabIndex : 0;
+        this.removeAttribute('tabindex');  // No tabindex means not tab-able or select-able.
+      } else if (!this.hasAttribute('tabindex')) {
+        this.setAttribute('tabindex', this._previousTabIndex);
+      }
     }
   };
 

--- a/test/iron-menu-behavior.html
+++ b/test/iron-menu-behavior.html
@@ -120,6 +120,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="disabled-group-and-options">
+      <template>
+        <test-menu disabled>
+          <div disabled>one</div>
+          <div disabled>two</div>
+        </test-menu>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="nonzero-tabindex">
+      <template>
+        <test-menu tabindex="32">
+          <div>One</div>
+          <div>Two</div>
+        </test-menu>
+      </template>
+    </test-fixture>
+
     <test-fixture id="countries">
       <template>
         <test-menu>
@@ -511,6 +529,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(Polymer.dom(document).activeElement, menu);
             done();
           });
+        });
+
+        test('A disabled menu should not be focusable', function(done) {
+          var menu = fixture('disabled-group-and-options');
+          menu.focus();
+          Polymer.Base.async(function() {
+            assert.notEqual(Polymer.dom(document).activeElement, menu);
+            assert.notEqual(Polymer.dom(document).activeElement, menu.items[0]);
+            assert.notEqual(Polymer.dom(document).activeElement, menu.items[1]);
+            done();
+          });
+        });
+
+        test('A disabled menu will not have a tab index.', function() {
+          var menu = fixture('countries');
+          assert.equal(menu.tabIndex, 0);
+          menu.disabled = true;
+          assert.equal(menu.tabIndex, -1);
+          menu.disabled = false;
+          assert.equal(menu.tabIndex, 0);
+        });
+
+        test('Updated tab index of disabled element should remain.', function() {
+          var menu = fixture('countries');
+          assert.equal(menu.tabIndex, 0);
+          menu.disabled = true;
+          assert.equal(menu.tabIndex, -1);
+          menu.setAttribute('tabindex', 15);
+          assert.equal(menu.tabIndex, 15);
+          menu.disabled = false;
+          assert.equal(menu.tabIndex, 15);
+        });
+
+        test('A disabled menu will regain its non-zero tab index when re-enabled.', function() {
+          var menu = fixture('nonzero-tabindex');
+          assert.equal(menu.tabIndex, 32);
+          menu.disabled = true;
+          assert.equal(menu.tabIndex, -1);
+          menu.disabled = false;
+          assert.equal(menu.tabIndex, 32);
         });
 
         test('`tabIndex` properties of all items are updated when items change', function(done) {


### PR DESCRIPTION
This PR was created because of https://github.com/PolymerElements/paper-radio-group/pull/77

This change fixes an issue where an element that uses IronMenuBehavior will focus one of its disabled children if all children are disabled. See: http://crbug.com/642644