### PR TITLE
Ignore keyEvent for "Shift" key pressed in order to support search for special symbols.

### DIFF
--- a/iron-menu-behavior.html
+++ b/iron-menu-behavior.html
@@ -133,6 +133,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @param {KeyboardEvent} event A KeyboardEvent.
      */
     _focusWithKeyboardEvent: function(event) {
+      if (event.key == "Shift")
+        return;
+
       this.cancelDebouncer('_clearSearchText');
 
       var searchText = this._searchText || '';


### PR DESCRIPTION
Otherwise, prefix search doesn't work for items containing underscore or other characters requiring Shift key.